### PR TITLE
Enable the checker in .merlin presence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+- Since there are projects that use build systems other than Dune, we
+  are opting to look for either `dune-project` or `.merlin`.
+
 ## 0.4.2 (2022-07-29)
 
 - Turns out Dune 2.8 stopped generating `.merlin` files (see [this article](https://tarides.com/blog/2021-01-26-recent-and-upcoming-changes-to-merlin)) - now we look for `dune-project` instead.


### PR DESCRIPTION
Problem: some projects don't use Dune, while using Merlin, configured
   with the .merlin file. `flycheck-ocaml` is only turned on if the
   «dune-project» file is present though. As a result,
   `flycheck-ocaml` is disabled for such projects.

Solution: enable the `flycheck-ocaml` checker if either dune-project
   or .merlin are present.

In a round-about way this fixes #15. People who don't use Dune, now 
  don't need to create an empty dune-project to use the checker, which
  was misleading.